### PR TITLE
Added better CSS starter code to template

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,11 @@
     "fix": "eslint ./src/**/*.tsx --fix"
   },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/src/components/Template.tsx
+++ b/src/components/Template.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import { Container, Box, Paper } from '@material-ui/core';
 
 /*
@@ -10,10 +10,11 @@ Otherwise, use <Box> components where possible for inline styling.
 Every page must have a Helmet tag for SEO purposes.
 */
 
-const useStyles = makeStyles({
-  example: {
-    color: 'red',
-  },
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    example: {
+      color: 'red',
+    },
 });
 
 const Template: React.FC = () => {

--- a/src/components/Template.tsx
+++ b/src/components/Template.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme: Theme) =>
     example: {
       color: 'red',
     },
-});
+}));
 
 const Template: React.FC = () => {
   const classes = useStyles();


### PR DESCRIPTION
Added equivalent CSS in JS starter code that allows use of the theme (inherited from ThemeProvider). This allows much easier access to theme variables.