### PR TITLE
Migrate frontend away from Travis CI for Continuous Integration Checks

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm run lint-and-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - 13.12.0
-script:
-  - npm run travis
-after_success:
-  - npm run coveralls

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,16 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm ci
+    build:
+      commands:
+        - npm run build
+  artifacts:
+    baseDirectory: build
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,19 +1,23 @@
 const CracoAntDesignPlugin = require('craco-antd');
-process.env.BROWSER = "none";
+process.env.BROWSER = 'none';
 module.exports = {
   plugins: [
     {
       plugin: CracoAntDesignPlugin,
       options: {
-        customizeTheme: {
-        },
+        customizeTheme: {},
       },
     },
   ],
   babel: {
     presets: [],
-    plugins: [['babel-plugin-styled-components', {
-      namespace: 'scaffold',
-    }]],
+    plugins: [
+      [
+        'babel-plugin-styled-components',
+        {
+          namespace: 'scaffold',
+        },
+      ],
+    ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "tslint -p . -c tslint.json && eslint ./src/**/*.tsx",
     "lint-fix": "tslint --fix -p . -c tslint.json && eslint --fix ./src/**/*.tsx",
-    "prettier": "prettier --check ./src/**/*.{ts,tsx,less}",
-    "prettier-fix": "prettier --write ./src/**/*.{ts,tsx,less}",
+    "prettier": "prettier --check .",
+    "prettier-fix": "prettier --write .",
     "type-check": "tsc",
     "check": "npm run lint-fix && npm run prettier-fix && npm run type-check",
-    "travis": "npm run lint && npm run prettier && npm run test && npm run build && npm run type-check"
+    "lint-and-test": "npm run lint && npm run prettier && npm run test"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "tslint -p . -c tslint.json && eslint ./src/**/*.tsx",
     "lint-fix": "tslint --fix -p . -c tslint.json && eslint --fix ./src/**/*.tsx",
-    "prettier": "prettier --check .",
-    "prettier-fix": "prettier --write .",
+    "prettier": "prettier --check src",
+    "prettier-fix": "prettier --write src",
     "type-check": "tsc",
     "check": "npm run lint-fix && npm run prettier-fix && npm run type-check",
     "lint-and-test": "npm run lint && npm run prettier && npm run test"


### PR DESCRIPTION
## Why

Travis CI limits open-source projects now. We need a new provider.

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

We'll be using GitHub Actions for Continuous Integration. This will build, test, and lint/prettier each pull request. 

For Continuous Delivery, we have already been using AWS Amplify to manage the deployment of `master` and we'll continue to use that. 

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Verification Steps

It ran on this PR! 
<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
