### PR TITLE
Changes to make frontend compatable with backend scaffold email verification

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,11 @@ const App: React.FC = () => {
                           exact
                           component={Settings}
                         />
+                        <Route
+                          path={Routes.VERIFY_EMAIL}
+                          exact
+                          component={VerifyEmail}
+                        />
                         <Route path="*" exact component={NotFound} />
                       </Switch>
                     );

--- a/src/containers/signup/index.tsx
+++ b/src/containers/signup/index.tsx
@@ -19,12 +19,19 @@ const { Title, Paragraph } = Typography;
 
 type SignupProps = UserAuthenticationReducerState;
 
+interface SignupFormData extends SignupRequest {
+  confirmPassword: string;
+}
+
 const Signup: React.FC<SignupProps> = ({ tokens }) => {
   const dispatch = useDispatch();
   const history = useHistory();
 
-  const onFinish = (values: SignupRequest) => {
-    dispatch(signup(values));
+  const onFinish = (values: SignupFormData) => {
+    // confirmPassword is checked in the form but should not be sent in the request
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { confirmPassword, ...request } = values;
+    dispatch(signup(request));
   };
 
   if (getPrivilegeLevel(tokens) !== PrivilegeLevel.NONE) {
@@ -59,14 +66,6 @@ const Signup: React.FC<SignupProps> = ({ tokens }) => {
           <Form.Item
             label="Email"
             name="email"
-            rules={[{ required: true, message: 'Required' }]}
-          >
-            <Input />
-          </Form.Item>
-
-          <Form.Item
-            label="Username"
-            name="username"
             rules={[{ required: true, message: 'Required' }]}
           >
             <Input />


### PR DESCRIPTION
## Why

To verify an email a user needs to create an account and then visit the link sent to them by the backend. This PR includes the necessary changes to make this work with the backend scaffold.

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

1. Removed username field from signup form because it is not in the data model we're using.
2. Changed types so that the confirmPassword key is not sent to the backend on signup since the backend is not expecting that field
3. Duplicated the verifyEmail route into the protected routes as well, typically a user will verify their email directly after signing up which means they'll have a valid JWT token in their local storage

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Verification Steps

Tested sending a verification email to myself locally running the backend scaffold and the frontend scaffold from creating a user to clicking the verify link.

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
