### PR TITLE
Add log out button

### DIFF
--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -103,7 +103,7 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
               localStorage.removeItem(LOCALSTORAGE_STATE_KEY);
             });
             history.push(Routes.HOME);
-            history.go(0) // force refresh to update privilege level
+            history.go(0); // force refresh if user is already on home page
           }
         }}
       >

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -7,11 +7,13 @@ import {
   PrivilegeLevel,
   UserAuthenticationReducerState,
 } from '../../auth/ducks/types';
-import { C4CState } from '../../store';
+import { C4CState, LOCALSTORAGE_STATE_KEY } from '../../store';
 import { connect } from 'react-redux';
 import { getPrivilegeLevel } from '../../auth/ducks/selectors';
 import { PRIMARY } from '../../utils/colors';
 import { Routes } from '../../App';
+import AuthClient from '../../auth/authClient';
+import { asyncRequestIsComplete } from '../../utils/asyncRequest';
 
 const { Text } = Typography;
 
@@ -93,6 +95,19 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
         }}
       >
         Settings
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          if (asyncRequestIsComplete(tokens)) {
+            AuthClient.logout(tokens.result.refreshToken).then(() => {
+              localStorage.removeItem(LOCALSTORAGE_STATE_KEY);
+            });
+            history.push(Routes.HOME);
+            history.go(0) // force refresh to update privilege level
+          }
+        }}
+      >
+        Log Out
       </Menu.Item>
     </Menu>
   );

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -7,13 +7,13 @@ import {
   PrivilegeLevel,
   UserAuthenticationReducerState,
 } from '../../auth/ducks/types';
-import { C4CState, LOCALSTORAGE_STATE_KEY } from '../../store';
-import { connect } from 'react-redux';
+import { C4CState } from '../../store';
+import { connect, useDispatch } from 'react-redux';
 import { getPrivilegeLevel } from '../../auth/ducks/selectors';
 import { PRIMARY } from '../../utils/colors';
 import { Routes } from '../../App';
-import AuthClient from '../../auth/authClient';
 import { asyncRequestIsComplete } from '../../utils/asyncRequest';
+import { logout } from '../../auth/ducks/thunks';
 
 const { Text } = Typography;
 
@@ -80,6 +80,7 @@ interface NavBarProps {
 const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
   const history = useHistory();
   const location = useLocation();
+  const dispatch = useDispatch();
 
   const privilegeLevel: PrivilegeLevel = getPrivilegeLevel(tokens);
   const links = {
@@ -99,9 +100,7 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
       <Menu.Item
         onClick={() => {
           if (asyncRequestIsComplete(tokens)) {
-            AuthClient.logout(tokens.result.refreshToken).then(() => {
-              localStorage.removeItem(LOCALSTORAGE_STATE_KEY);
-            });
+            dispatch(logout());
             history.push(Routes.HOME);
             history.go(0); // force refresh if user is already on home page
           }

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -102,7 +102,6 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
           if (asyncRequestIsComplete(tokens)) {
             dispatch(logout());
             history.push(Routes.HOME);
-            history.go(0); // force refresh if user is already on home page
           }
         }}
       >


### PR DESCRIPTION
Closes issue #67 in [LLB frontend](https://github.com/Code-4-Community/lucys-love-bus-frontend/issues/67).

This PR adds a log out button to the dropdown of the navigation bar. I added a "Log Out" menu item, and upon click, it removes the state in the localStorage, and routes the user to the home page. 

Screenshots:

Log out button:
![image](https://user-images.githubusercontent.com/46979800/111922889-e81c3680-8a72-11eb-90f8-569644fd2210.png)

Before logging in (localStorage is empty):
![image](https://user-images.githubusercontent.com/46979800/111922905-f9fdd980-8a72-11eb-935f-89b70b1a54d3.png)

After logging in (localStorage is updated with state):
![image](https://user-images.githubusercontent.com/46979800/111922915-0aae4f80-8a73-11eb-943d-86ac2ca77324.png)

After clicking the newly added log out button, back at the home page (localStorage is cleared out):
![image](https://user-images.githubusercontent.com/46979800/111922969-34677680-8a73-11eb-991f-c4c81fa503e4.png)

cc: @varunthakkar1 