### PR TITLE
adding notstarted to generic async actions and reducer

### DIFF
--- a/src/auth/ducks/actions.ts
+++ b/src/auth/ducks/actions.ts
@@ -13,4 +13,4 @@ export type UserAuthenticationActions =
   | ReturnType<typeof authenticateUser.failed>
   | ReturnType<typeof logoutUser.loading>
   | ReturnType<typeof logoutUser.loaded>
-  | ReturnType<typeof logoutUser.failed>
+  | ReturnType<typeof logoutUser.failed>;

--- a/src/auth/ducks/actions.ts
+++ b/src/auth/ducks/actions.ts
@@ -5,10 +5,12 @@ export const authenticateUser = genericAsyncActions<TokenPayload, any>();
 
 export const logoutUser = genericAsyncActions<void, void>();
 
+
 export type UserAuthenticationActions =
+  | ReturnType<typeof authenticateUser.notStarted>
   | ReturnType<typeof authenticateUser.loading>
   | ReturnType<typeof authenticateUser.loaded>
   | ReturnType<typeof authenticateUser.failed>
   | ReturnType<typeof logoutUser.loading>
   | ReturnType<typeof logoutUser.loaded>
-  | ReturnType<typeof logoutUser.failed>;
+  | ReturnType<typeof logoutUser.failed>

--- a/src/auth/ducks/actions.ts
+++ b/src/auth/ducks/actions.ts
@@ -5,7 +5,6 @@ export const authenticateUser = genericAsyncActions<TokenPayload, any>();
 
 export const logoutUser = genericAsyncActions<void, void>();
 
-
 export type UserAuthenticationActions =
   | ReturnType<typeof authenticateUser.notStarted>
   | ReturnType<typeof authenticateUser.loading>

--- a/src/auth/ducks/reducers.ts
+++ b/src/auth/ducks/reducers.ts
@@ -1,12 +1,11 @@
 import { C4CAction } from '../../store';
 import {
-  AsyncRequestNotStarted, ASYNC_REQUEST_FAILED_ACTION,
+  AsyncRequestNotStarted,
+  ASYNC_REQUEST_FAILED_ACTION,
   ASYNC_REQUEST_LOADED_ACTION,
   ASYNC_REQUEST_LOADING_ACTION,
-
   ASYNC_REQUEST_NOT_STARTED_ACTION,
-
-  generateAsyncRequestReducer
+  generateAsyncRequestReducer,
 } from '../../utils/asyncRequest';
 import { authenticateUser } from './actions';
 import { TokenPayload, UserAuthenticationReducerState } from './types';

--- a/src/auth/ducks/reducers.ts
+++ b/src/auth/ducks/reducers.ts
@@ -1,13 +1,15 @@
-import { TokenPayload, UserAuthenticationReducerState } from './types';
-import { authenticateUser } from './actions';
 import { C4CAction } from '../../store';
 import {
-  ASYNC_REQUEST_FAILED_ACTION,
+  AsyncRequestNotStarted, ASYNC_REQUEST_FAILED_ACTION,
   ASYNC_REQUEST_LOADED_ACTION,
   ASYNC_REQUEST_LOADING_ACTION,
-  AsyncRequestNotStarted,
-  generateAsyncRequestReducer,
+
+  ASYNC_REQUEST_NOT_STARTED_ACTION,
+
+  generateAsyncRequestReducer
 } from '../../utils/asyncRequest';
+import { authenticateUser } from './actions';
+import { TokenPayload, UserAuthenticationReducerState } from './types';
 
 export const initialUserState: UserAuthenticationReducerState = {
   tokens: AsyncRequestNotStarted<TokenPayload, any>(),
@@ -24,6 +26,7 @@ const reducers = (
   action: C4CAction,
 ): UserAuthenticationReducerState => {
   switch (action.type) {
+    case ASYNC_REQUEST_NOT_STARTED_ACTION:
     case ASYNC_REQUEST_LOADING_ACTION:
     case ASYNC_REQUEST_LOADED_ACTION:
     case ASYNC_REQUEST_FAILED_ACTION:

--- a/src/auth/ducks/thunks.ts
+++ b/src/auth/ducks/thunks.ts
@@ -6,7 +6,7 @@ import {
   LoginRequest,
   SignupRequest,
   TokenPayload,
-  UserAuthenticationThunkAction
+  UserAuthenticationThunkAction,
 } from './types';
 
 export const login = (
@@ -48,7 +48,7 @@ export const signup = (
 export const logout = (): UserAuthenticationThunkAction<void> => {
   return (dispatch, getState, { authClient }): Promise<void> => {
     localStorage.removeItem(LOCALSTORAGE_STATE_KEY);
-    dispatch(authenticateUser.notStarted())
+    dispatch(authenticateUser.notStarted());
     const state: C4CState = getState();
 
     if (asyncRequestIsComplete(state.authenticationState.tokens)) {

--- a/src/auth/ducks/thunks.ts
+++ b/src/auth/ducks/thunks.ts
@@ -1,13 +1,13 @@
+import { C4CState, LOCALSTORAGE_STATE_KEY } from '../../store';
+import { asyncRequestIsComplete } from '../../utils/asyncRequest';
+import AppAxiosInstance from '../axios';
+import { authenticateUser, logoutUser } from './actions';
 import {
   LoginRequest,
   SignupRequest,
   TokenPayload,
-  UserAuthenticationThunkAction,
+  UserAuthenticationThunkAction
 } from './types';
-import { authenticateUser, logoutUser } from './actions';
-import { C4CState, LOCALSTORAGE_STATE_KEY } from '../../store';
-import { asyncRequestIsComplete } from '../../utils/asyncRequest';
-import AppAxiosInstance from '../axios';
 
 export const login = (
   loginRequest: LoginRequest,
@@ -48,7 +48,7 @@ export const signup = (
 export const logout = (): UserAuthenticationThunkAction<void> => {
   return (dispatch, getState, { authClient }): Promise<void> => {
     localStorage.removeItem(LOCALSTORAGE_STATE_KEY);
-
+    dispatch(authenticateUser.notStarted())
     const state: C4CState = getState();
 
     if (asyncRequestIsComplete(state.authenticationState.tokens)) {

--- a/src/auth/test/reducers.test.ts
+++ b/src/auth/test/reducers.test.ts
@@ -19,4 +19,20 @@ describe('User Authentication Reducers', () => {
 
     expect(reducers(initialUserState, action)).toEqual(expectedNextState);
   });
+
+  it('Clears tokens correctly when setting state to NotStarted', () => {
+    const payload: TokenPayload = {
+      accessToken:
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJjNGMiLCJleHAiOjE2MDQ4NzIwODIsInVzZXJuYW1lIjoiamFja2JsYW5jIn0.k0D1rySdVqVatWsjdA4i1YYq-7glzrL3ycSQwz-5zLU',
+      refreshToken:
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJjNGMiLCJleHAiOjE2MDU0NzUwODIsInVzZXJuYW1lIjoiamFja2JsYW5jIn0.FHgEdtz16H5u7mtTqE81N4PUsnzjvwdaJ4GK_jdLWAY',
+    };
+    const action = authenticateUser.notStarted();
+    const authenticatedState: UserAuthenticationReducerState = {
+      ...initialUserState,
+      tokens: AsyncRequestCompleted<TokenPayload, void>(payload),
+    };
+
+    expect(reducers(authenticatedState, action)).toEqual(initialUserState);
+  });
 });

--- a/src/utils/asyncRequest.ts
+++ b/src/utils/asyncRequest.ts
@@ -179,7 +179,10 @@ export type AsyncRequestAction<R, E> =
   | Action<typeof ASYNC_REQUEST_FAILED_ACTION, FailedPayload<E>>;
 
 export function genericAsyncActions<R, E>(): {
-  notStarted: () => Action<typeof ASYNC_REQUEST_NOT_STARTED_ACTION, NotStartedPayload>;
+  notStarted: () => Action<
+    typeof ASYNC_REQUEST_NOT_STARTED_ACTION,
+    NotStartedPayload
+  >;
   loading: () => Action<typeof ASYNC_REQUEST_LOADING_ACTION, LoadingPayload>;
   loaded: (
     r: R,

--- a/src/utils/asyncRequest.ts
+++ b/src/utils/asyncRequest.ts
@@ -1,6 +1,6 @@
-import { Action } from '../store';
 import { Reducer } from 'redux';
 import { v4 } from 'uuid';
+import { Action } from '../store';
 
 export enum AsyncRequestKinds {
   NotStarted = 'NotStarted',
@@ -152,10 +152,14 @@ export function rehydrateAsyncRequest<R, E = void>(
       return request;
   }
 }
-
+export const ASYNC_REQUEST_NOT_STARTED_ACTION = 'asyncNotStarted';
 export const ASYNC_REQUEST_LOADING_ACTION = 'asyncLoading';
 export const ASYNC_REQUEST_LOADED_ACTION = 'asyncLoaded';
 export const ASYNC_REQUEST_FAILED_ACTION = 'asyncFailed';
+
+interface NotStartedPayload {
+  readonly key: string;
+}
 interface LoadingPayload {
   readonly key: string;
 }
@@ -169,11 +173,13 @@ interface FailedPayload<E> {
 }
 
 export type AsyncRequestAction<R, E> =
+  | Action<typeof ASYNC_REQUEST_NOT_STARTED_ACTION, NotStartedPayload>
   | Action<typeof ASYNC_REQUEST_LOADING_ACTION, LoadingPayload>
   | Action<typeof ASYNC_REQUEST_LOADED_ACTION, LoadedPayload<R>>
   | Action<typeof ASYNC_REQUEST_FAILED_ACTION, FailedPayload<E>>;
 
 export function genericAsyncActions<R, E>(): {
+  notStarted: () => Action<typeof ASYNC_REQUEST_NOT_STARTED_ACTION, NotStartedPayload>;
   loading: () => Action<typeof ASYNC_REQUEST_LOADING_ACTION, LoadingPayload>;
   loaded: (
     r: R,
@@ -184,6 +190,14 @@ export function genericAsyncActions<R, E>(): {
   key: string;
 } {
   const key = v4(); // UUID4
+
+  const notStarted = (): Action<
+    typeof ASYNC_REQUEST_NOT_STARTED_ACTION,
+    NotStartedPayload
+  > => ({
+    type: ASYNC_REQUEST_NOT_STARTED_ACTION,
+    payload: { key },
+  });
 
   const loading = (): Action<
     typeof ASYNC_REQUEST_LOADING_ACTION,
@@ -208,6 +222,7 @@ export function genericAsyncActions<R, E>(): {
   });
 
   return {
+    notStarted,
     loading,
     loaded,
     failed,
@@ -224,6 +239,11 @@ export function generateAsyncRequestReducer<S, R, E>(key: string) {
     action: AsyncRequestAction<any, any>,
   ) => {
     switch (action.type) {
+      case ASYNC_REQUEST_NOT_STARTED_ACTION:
+        if (action.payload.key === key) {
+          return AsyncRequestNotStarted<R, E>();
+        }
+        break;
       case ASYNC_REQUEST_LOADING_ACTION:
         if (action.payload.key === key) {
           return AsyncRequestLoading<R, E>();

--- a/src/utils/test/asyncRequest.test.ts
+++ b/src/utils/test/asyncRequest.test.ts
@@ -9,6 +9,7 @@ import {
   AsyncRequestFailed,
   AsyncRequestCompleted,
   rehydrateAsyncRequest,
+  ASYNC_REQUEST_NOT_STARTED_ACTION,
 } from '../asyncRequest';
 import {
   PrivilegeLevel,
@@ -34,6 +35,10 @@ describe('asyncRequest ', () => {
       const err = new Error();
       const response = 'myResponse';
 
+      expect(generator1.notStarted()).toEqual({
+        type: ASYNC_REQUEST_NOT_STARTED_ACTION,
+        payload: { key: generator1.key },
+      });
       expect(generator1.loading()).toEqual({
         type: ASYNC_REQUEST_LOADING_ACTION,
         payload: { key: generator1.key },
@@ -57,6 +62,12 @@ describe('asyncRequest ', () => {
       TokenPayload,
       Error
     >(actions.key);
+
+    it('updates the state for a not started action with given key', () => {
+      expect(reducer(initialState, actions.notStarted())).toEqual(
+        AsyncRequestNotStarted<TokenPayload, Error>(),
+      );
+    });
 
     it('updates the state for a loading action with given key', () => {
       expect(reducer(initialState, actions.loading())).toEqual(


### PR DESCRIPTION
## Why

When logging out and deleting the user we need to clear tokens in redux, we currently dont have the ability to do this with an action, so this PR aims to add that feature.