### PR TITLE
Update AsyncRequest utility types

### DIFF
--- a/src/utils/asyncRequest.ts
+++ b/src/utils/asyncRequest.ts
@@ -99,7 +99,7 @@ export function asyncRequestIsComplete<R, E = void>(
 
 export function asyncRequestIsLoading<R, E = void>(
   request: AsyncRequest<R, E>,
-): boolean {
+): request is Loading {
   switch (request.kind) {
     case AsyncRequestKinds.Loading:
       return true;
@@ -112,7 +112,7 @@ export function asyncRequestIsLoading<R, E = void>(
 
 export function asyncRequestIsFailed<R, E = void>(
   request: AsyncRequest<R, E>,
-): boolean {
+): request is Failed<E> {
   switch (request.kind) {
     case AsyncRequestKinds.Failed:
       return true;
@@ -125,7 +125,7 @@ export function asyncRequestIsFailed<R, E = void>(
 
 export function asyncRequestIsNotStarted<R, E = void>(
   request: AsyncRequest<R, E>,
-): boolean {
+): request is NotStarted {
   switch (request.kind) {
     case AsyncRequestKinds.NotStarted:
       return true;

--- a/src/utils/test/asyncRequest.test.ts
+++ b/src/utils/test/asyncRequest.test.ts
@@ -1,18 +1,20 @@
 import {
-  AsyncRequestLoading,
-  AsyncRequestNotStarted,
   ASYNC_REQUEST_FAILED_ACTION,
-  generateAsyncRequestReducer,
-  genericAsyncActions,
   ASYNC_REQUEST_LOADED_ACTION,
   ASYNC_REQUEST_LOADING_ACTION,
-  AsyncRequestFailed,
-  AsyncRequestCompleted,
-  rehydrateAsyncRequest,
   ASYNC_REQUEST_NOT_STARTED_ACTION,
+  AsyncRequest,
+  AsyncRequestCompleted,
+  AsyncRequestFailed,
+  asyncRequestIsComplete, asyncRequestIsFailed, asyncRequestIsLoading,
+  asyncRequestIsNotStarted,
+  AsyncRequestLoading,
+  AsyncRequestNotStarted,
+  generateAsyncRequestReducer,
+  genericAsyncActions,
+  rehydrateAsyncRequest,
 } from '../asyncRequest';
 import {
-  PrivilegeLevel,
   TokenPayload,
   UserAuthenticationReducerState,
 } from '../../auth/ducks/types';
@@ -130,5 +132,69 @@ describe('asyncRequest ', () => {
 
       expect(rehydrateAsyncRequest(loadingRequest)).toEqual(notStartedRequest);
     });
+  });
+
+  describe('asyncRequestIsX utilities', () => {
+    const notStartedRequest = AsyncRequestNotStarted<string, string>();
+    const loadingRequest = AsyncRequestLoading<string, string>();
+    const completedRequest = AsyncRequestCompleted<string, string>('result!');
+    const failedRequest = AsyncRequestFailed<string, string>('error!');
+
+    const asyncRequests: AsyncRequest<string, string>[] = [
+      notStartedRequest,
+      loadingRequest,
+      completedRequest,
+      failedRequest,
+    ];
+
+    it('asyncRequestIsNotStarted identifies NotStarted asyncRequests', () => {
+      asyncRequests.map(
+        (asyncRequest: AsyncRequest<string, string>, index: number) => {
+          if (index === 0) {
+            expect(asyncRequestIsNotStarted(asyncRequest)).toEqual(true);
+          } else {
+            expect(asyncRequestIsNotStarted(asyncRequest)).toEqual(false);
+          }
+        },
+      );
+    });
+
+    it('asyncRequestIsLoading identifies Loading asyncRequests', () => {
+      asyncRequests.map(
+        (asyncRequest: AsyncRequest<string, string>, index: number) => {
+          if (index === 1) {
+            expect(asyncRequestIsLoading(asyncRequest)).toEqual(true);
+          } else {
+            expect(asyncRequestIsLoading(asyncRequest)).toEqual(false);
+          }
+        },
+      );
+    });
+
+    it('asyncRequestIsComplete identifies Complete asyncRequests', () => {
+      asyncRequests.map(
+        (asyncRequest: AsyncRequest<string, string>, index: number) => {
+          if (index === 2) {
+            expect(asyncRequestIsComplete(asyncRequest)).toEqual(true);
+          } else {
+            expect(asyncRequestIsComplete(asyncRequest)).toEqual(false);
+          }
+        },
+      );
+    });
+
+
+    it('asyncRequestIsFailed identifies Failed asyncRequests', () => {
+      asyncRequests.map(
+        (asyncRequest: AsyncRequest<string, string>, index: number) => {
+          if (index === 3) {
+            expect(asyncRequestIsFailed(asyncRequest)).toEqual(true);
+          } else {
+            expect(asyncRequestIsFailed(asyncRequest)).toEqual(false);
+          }
+        },
+      );
+    });
+
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -13,7 +17,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
## Why

Type safety!

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

Changes the return types of our asyncRequestIsX utilities to `request is X` instead of `boolean`.

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->


## Verification Steps

Tests!