### PR TITLE
User Data, Change Throttle

### DIFF
--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -1,4 +1,5 @@
 import AppAxiosInstance from '../auth/axios';
+import { UserData } from '../auth/ducks/types';
 
 export interface ProtectedApiClient {
   readonly changePassword: (request: {
@@ -6,11 +7,13 @@ export interface ProtectedApiClient {
     newPassword: string;
   }) => Promise<void>;
   readonly deleteUser: (request: { password: string }) => Promise<void>;
+  readonly getUserData: () => Promise<UserData>;
 }
 
 export enum ProtectedApiClientRoutes {
   CHANGE_PASSWORD = '/api/v1/protected/user/change_password',
   DELETE_USER = '/api/v1/protected/user/',
+  USER_DATA = '/api/v1/protected/user/data',
 }
 
 const changePassword = (request: {
@@ -31,9 +34,16 @@ const deleteUser = (request: { password: string }): Promise<void> => {
     .catch((e) => e);
 };
 
+const getUserData = (): Promise<UserData> => {
+  return AppAxiosInstance.get(ProtectedApiClientRoutes.USER_DATA)
+    .then((res) => res.data)
+    .catch((err) => err);
+};
+
 const Client: ProtectedApiClient = Object.freeze({
   changePassword,
   deleteUser,
+  getUserData,
 });
 
 export default Client;

--- a/src/auth/ducks/actions.ts
+++ b/src/auth/ducks/actions.ts
@@ -1,9 +1,11 @@
 import { genericAsyncActions } from '../../utils/asyncRequest';
-import { TokenPayload } from './types';
+import { TokenPayload, UserData } from './types';
 
 export const authenticateUser = genericAsyncActions<TokenPayload, any>();
 
 export const logoutUser = genericAsyncActions<void, void>();
+
+export const userData = genericAsyncActions<UserData, any>();
 
 export type UserAuthenticationActions =
   | ReturnType<typeof authenticateUser.notStarted>
@@ -12,4 +14,7 @@ export type UserAuthenticationActions =
   | ReturnType<typeof authenticateUser.failed>
   | ReturnType<typeof logoutUser.loading>
   | ReturnType<typeof logoutUser.loaded>
-  | ReturnType<typeof logoutUser.failed>;
+  | ReturnType<typeof logoutUser.failed>
+  | ReturnType<typeof userData.loading>
+  | ReturnType<typeof userData.loaded>
+  | ReturnType<typeof userData.failed>;

--- a/src/auth/ducks/reducers.ts
+++ b/src/auth/ducks/reducers.ts
@@ -7,11 +7,16 @@ import {
   ASYNC_REQUEST_NOT_STARTED_ACTION,
   generateAsyncRequestReducer,
 } from '../../utils/asyncRequest';
-import { authenticateUser } from './actions';
-import { TokenPayload, UserAuthenticationReducerState } from './types';
+import { authenticateUser, userData } from './actions';
+import {
+  TokenPayload,
+  UserAuthenticationReducerState,
+  UserData,
+} from './types';
 
 export const initialUserState: UserAuthenticationReducerState = {
   tokens: AsyncRequestNotStarted<TokenPayload, any>(),
+  userData: AsyncRequestNotStarted<UserData, string>(),
 };
 
 const userAuthenticationRequestReducer = generateAsyncRequestReducer<
@@ -19,6 +24,12 @@ const userAuthenticationRequestReducer = generateAsyncRequestReducer<
   TokenPayload,
   void
 >(authenticateUser.key);
+
+const userDataRequestReducer = generateAsyncRequestReducer<
+  UserAuthenticationReducerState,
+  UserData,
+  string
+>(userData.key);
 
 const reducers = (
   state: UserAuthenticationReducerState = initialUserState,
@@ -32,6 +43,7 @@ const reducers = (
       return {
         ...state,
         tokens: userAuthenticationRequestReducer(state.tokens, action),
+        userData: userDataRequestReducer(state.userData, action),
       };
     default:
       return state;

--- a/src/auth/ducks/selectors.ts
+++ b/src/auth/ducks/selectors.ts
@@ -30,3 +30,9 @@ export const isTokenValid = (token: string): boolean => {
   const payload = JSON.parse(atob(token.split('.')[1]));
   return payload && Math.round(Date.now() / 1000) < payload.exp;
 };
+
+export const getFullName = (userData: UserAuthenticationReducerState['userData']): string | undefined => {
+  if (asyncRequestIsComplete(userData)) {
+    return `${userData.result.firstName} ${userData.result.lastName}`
+  }
+}

--- a/src/auth/ducks/thunks.ts
+++ b/src/auth/ducks/thunks.ts
@@ -1,12 +1,13 @@
 import { C4CState, LOCALSTORAGE_STATE_KEY } from '../../store';
 import { asyncRequestIsComplete } from '../../utils/asyncRequest';
 import AppAxiosInstance from '../axios';
-import { authenticateUser, logoutUser } from './actions';
+import { authenticateUser, logoutUser, userData } from './actions';
 import {
   LoginRequest,
   SignupRequest,
   TokenPayload,
   UserAuthenticationThunkAction,
+  UserData,
 } from './types';
 
 export const login = (
@@ -66,5 +67,19 @@ export const logout = (): UserAuthenticationThunkAction<void> => {
       dispatch(logoutUser.loaded());
       return Promise.resolve();
     }
+  };
+};
+
+export const getUserData = (): UserAuthenticationThunkAction<void> => {
+  return (dispatch, getState, { protectedApiClient }): Promise<void> => {
+    dispatch(userData.loading());
+    return protectedApiClient
+      .getUserData()
+      .then((response: UserData) => {
+        dispatch(userData.loaded(response));
+      })
+      .catch((error) => {
+        dispatch(userData.failed(error.response.data));
+      });
   };
 };

--- a/src/auth/ducks/types.ts
+++ b/src/auth/ducks/types.ts
@@ -3,13 +3,16 @@ import { AuthClient } from '../authClient';
 import { AsyncRequest } from '../../utils/asyncRequest';
 import { UserAuthenticationActions } from './actions';
 import { C4CState } from '../../store';
+import { ProtectedApiClient } from '../../api/protectedApiClient';
 
 export interface UserAuthenticationReducerState {
   readonly tokens: AsyncRequest<TokenPayload, any>;
+  readonly userData: AsyncRequest<UserData, string>;
 }
 
 export interface UserAuthenticationExtraArgs {
   readonly authClient: AuthClient;
+  readonly protectedApiClient: ProtectedApiClient;
 }
 
 export type UserAuthenticationThunkAction<R> = ThunkAction<
@@ -47,6 +50,12 @@ export interface TokenPayload {
 
 export interface RefreshTokenResponse {
   readonly freshAccessToken: string;
+}
+
+export interface UserData {
+  firstName: string;
+  lastName: string;
+  email: string;
 }
 
 export enum PrivilegeLevel {

--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -1,11 +1,28 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { Typography } from 'antd';
 import { ContentContainer } from '../../components';
+import { PrivilegeLevel } from '../../auth/ducks/types';
+import { useDispatch, useSelector } from 'react-redux';
+import { C4CState } from '../../store';
+import { getFullName, getPrivilegeLevel } from '../../auth/ducks/selectors';
+import { getUserData } from '../../auth/ducks/thunks';
 
 const { Title } = Typography;
 
 const Home: React.FC = () => {
+  const dispatch = useDispatch();
+
+  const privilegeLevel: PrivilegeLevel = useSelector((state: C4CState) =>
+    getPrivilegeLevel(state.authenticationState.tokens),
+  );
+
+  useEffect(() => {
+    dispatch(getUserData());
+  }, [dispatch, privilegeLevel])
+  const name: string | undefined = useSelector((state: C4CState) =>
+    getFullName(state.authenticationState.userData),
+  );
   return (
     <>
       <Helmet>
@@ -16,10 +33,8 @@ const Home: React.FC = () => {
         />
       </Helmet>
       <ContentContainer>
-        <Title>Code4Community Frontend Scaffold</Title>
-        <Title level={3}>
-          Built with React.js, Typescript, Redux, and AntD components.
-        </Title>
+        <Title>Hello, {name}</Title>
+        <Title level={3}>Your privilege level is: {privilegeLevel}</Title>
       </ContentContainer>
     </>
   );

--- a/src/containers/login/index.tsx
+++ b/src/containers/login/index.tsx
@@ -17,7 +17,9 @@ import { getPrivilegeLevel } from '../../auth/ducks/selectors';
 
 const { Title, Paragraph } = Typography;
 
-type LoginProps = UserAuthenticationReducerState;
+interface LoginProps {
+  readonly tokens: UserAuthenticationReducerState['tokens'];
+}
 
 const Login: React.FC<LoginProps> = ({ tokens }) => {
   const dispatch = useDispatch();

--- a/src/containers/signup/index.tsx
+++ b/src/containers/signup/index.tsx
@@ -17,7 +17,9 @@ import { Routes } from '../../App';
 
 const { Title, Paragraph } = Typography;
 
-type SignupProps = UserAuthenticationReducerState;
+interface SignupProps {
+  readonly tokens: UserAuthenticationReducerState['tokens']
+}
 
 interface SignupFormData extends SignupRequest {
   confirmPassword: string;

--- a/src/store.ts
+++ b/src/store.ts
@@ -17,6 +17,7 @@ import thunk from 'redux-thunk';
 import throttle from 'lodash/throttle';
 import AppAxiosInstance from './auth/axios';
 import { asyncRequestIsComplete } from './utils/asyncRequest';
+import protectedApiClient from './api/protectedApiClient';
 
 export interface C4CState {
   authenticationState: UserAuthenticationReducerState;
@@ -62,6 +63,7 @@ const preloadedState: C4CState | undefined = loadStateFromLocalStorage();
 
 const thunkExtraArgs: ThunkExtraArgs = {
   authClient,
+  protectedApiClient,
 };
 
 const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
@@ -93,7 +95,7 @@ store.subscribe(
     } catch {
       // ignore write errors
     }
-  }, 10000),
+  }, 1000),
 );
 
 export default store;


### PR DESCRIPTION
## Why

We need to be able to verify easily that the frontend scaffold can make requests.

## This PR

Adds userData to the auth duck. 

Alters `throttle` in the store to run every second, not 10. This makes sure that tokens are stored before a user refreshes the page.

## Verification Steps

Ran locally, viewed that data was loaded properly. 
